### PR TITLE
handle server_ready option in plack handler

### DIFF
--- a/lib/Plack/Handler/Feersum.pm
+++ b/lib/Plack/Handler/Feersum.pm
@@ -14,6 +14,14 @@ sub assign_request_handler {
     return;
 }
 
+sub _prepare {
+    my $self = shift;
+    $self->SUPER::_prepare(@_);
+    $self->{server_ready}->($self)
+        if $self->{server_ready};
+    return;
+}
+
 1;
 __END__
 


### PR DESCRIPTION
Plack::Runner uses server_ready to add a startup message in development
mode.