### PR TITLE
add missing whatis entry

### DIFF
--- a/lib/Feersum/Runner.pm
+++ b/lib/Feersum/Runner.pm
@@ -178,7 +178,7 @@ __END__
 
 =head1 NAME
 
-Feersum::Runner
+Feersum::Runner - feersum script core
 
 =head1 SYNOPSIS
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to Feersum.
We thought you might be interested in it too.

    Description: add missing whatis entry
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-03-22
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/feersum/raw/master/debian/patches/pod-whatis.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
