### PR TITLE
fix spelling mistake

### DIFF
--- a/lib/Feersum/Connection.pm
+++ b/lib/Feersum/Connection.pm
@@ -84,7 +84,7 @@ For a response with a Content-Length header:
 
 =head1 DESCRIPTION
 
-Encapsulates an HTTP connection to Feersum.  It's roughly analagous to an
+Encapsulates an HTTP connection to Feersum.  It's roughly analogous to an
 C<Apache::Request> or C<Apache2::Connection> object, but differs significantly
 in functionality.
 


### PR DESCRIPTION

In Debian we are currently applying the following patch to Feersum.
We thought you might be interested in it too.

    Description: fix spelling mistake
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-03-22
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/feersum/raw/master/debian/patches/pod-spelling.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
