### PR TITLE
add missing use statement

### DIFF
--- a/lib/Feersum/Connection/Handle.pm
+++ b/lib/Feersum/Connection/Handle.pm
@@ -1,6 +1,7 @@
 package Feersum::Connection::Handle;
 use warnings;
 use strict;
+use Carp qw/croak/;
 
 sub new {
     Carp::croak "Cannot instantiate Feersum::Connection::Handles directly";


### PR DESCRIPTION

In Debian we are currently applying the following patch to Feersum.
We thought you might be interested in it too.

    Description: add missing use statement
     Otherwise we get a syntax error:
     syntax error at /usr/lib/x86_64-linux-gnu/perl5/5.26/Feersum/Connection/Handle.pm line 6, near "Carp::croak "Cannot instantiate Feersum::Connection::Handles directly""
    Origin: vendor
    Author: gregor herrmann <gregoa@debian.org>
    Last-Update: 2018-03-22
    

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/feersum/raw/master/debian/patches/use-carp.patch

Thanks for considering,
  gregor herrmann,
  Debian Perl Group
