### PR TITLE
Fix broken unit test 07-graceful-shutdown.t

### DIFF
--- a/Feersum.xs
+++ b/Feersum.xs
@@ -1576,13 +1576,13 @@ feersum_env(pTHX_ struct feer_conn *c)
     hv_stores(e, "REMOTE_ADDR", addr);
     hv_stores(e, "REMOTE_PORT", port);
 
-    // if (unlikely(c->expected_cl > 0)) { /* #23 - POST can still have empty content */
+    if (unlikely(c->expected_cl > 0)) {
         hv_stores(e, "CONTENT_LENGTH", newSViv(c->expected_cl));
         hv_stores(e, "psgi.input", new_feer_conn_handle(aTHX_ c,0));
-    // }
-    // else if (request_cb_is_psgi) {
+    }
+    else if (request_cb_is_psgi) {
         // TODO: make psgi.input a valid, but always empty stream for PSGI mode?
-    // }
+    }
 
     if (request_cb_is_psgi) {
         SV *fake_fh = newSViv(c->fd); // just some random dummy value

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -88,6 +88,7 @@ WriteMakefile(ev_args(
     PREREQ_PM => {
         'EV' => 4.00,
         'Scalar::Util' => 1.19,
+        'HTTP::Entity::Parser' => '0.20',
         map { $_ => $want{$_} } grep { !/^Test::/ && $have{$_} } keys %want
     },
     META_MERGE => {


### PR DESCRIPTION
The change introduced in 1.405 broke the graceful shutdown unit test. This change has been reverted and instead can be fixed by requiring `HTTP::Entity::Parser` 0.20 or later.

This also addresses issue #23